### PR TITLE
Issue 14

### DIFF
--- a/tests/unit/test_mane_transcript.py
+++ b/tests/unit/test_mane_transcript.py
@@ -240,17 +240,6 @@ def test_get_mane_p(test_mane_transcript, braf_mane_data, braf_v600e_mane_p):
 async def test_p_to_mane_p(test_mane_transcript, braf_v600e_mane_p,
                            egfr_l858r_mane_p):
     """Test that p_to_mane_p method works correctly."""
-    mane_p = await test_mane_transcript.get_mane_transcript(
-        'ENSP00000366997.4', 63, 63, 'P', gene='DIS3', ref='P',
-        try_longest_compatible=True)
-    assert mane_p == {
-        'gene': 'DIS3',
-        'refseq': 'NP_055768.3',
-        'ensembl': 'ENSP00000366997.4',
-        'pos': (62, 62),
-        'strand': '-',
-        'status': 'MANE Select'
-    }
     # BRAF V600E RefSeq Accessions
     mane_p = await test_mane_transcript.get_mane_transcript(
         'NP_004324.2', 600, None, 'p')

--- a/tests/unit/test_mane_transcript.py
+++ b/tests/unit/test_mane_transcript.py
@@ -242,62 +242,63 @@ async def test_p_to_mane_p(test_mane_transcript, braf_v600e_mane_p,
     """Test that p_to_mane_p method works correctly."""
     # BRAF V600E RefSeq Accessions
     mane_p = await test_mane_transcript.get_mane_transcript(
-        'NP_004324.2', 599, None, 'p', residue_mode='inter-residue')
+        'NP_004324.2', 599, 'p', residue_mode='inter-residue')
     assert mane_p == braf_v600e_mane_p
 
     mane_p = await test_mane_transcript.get_mane_transcript(
-        'NP_004324.2', 600, None, 'p')
+        'NP_004324.2', 600, 'p')
     assert mane_p == braf_v600e_mane_p
 
     mane_p = await test_mane_transcript.get_mane_transcript(
-        'NP_004324.2', 599, 599, 'p', residue_mode='inter-residue')
+        'NP_004324.2', 599, 'p', residue_mode='inter-residue', end_pos=599)
     assert mane_p == braf_v600e_mane_p
 
     mane_p = await test_mane_transcript.get_mane_transcript(
-        'NP_004324.2', 600, 600, 'p')
+        'NP_004324.2', 600, 'p', end_pos=600)
     assert mane_p == braf_v600e_mane_p
 
     # BRAF V600E Ensembl Accessions
     mane_p = await test_mane_transcript.get_mane_transcript(
-        'ENSP00000288602.7', 599, None, 'p', residue_mode='inter-residue')
+        'ENSP00000288602.7', 599, 'p', residue_mode='inter-residue')
     assert mane_p == braf_v600e_mane_p
 
     mane_p = await test_mane_transcript.get_mane_transcript(
-        'ENSP00000288602.7', 600, None, 'p')
+        'ENSP00000288602.7', 600, 'p')
     assert mane_p == braf_v600e_mane_p
 
     mane_p = await test_mane_transcript.get_mane_transcript(
-        'ENSP00000288602.7', 599, 599, 'p', residue_mode='inter-residue')
+        'ENSP00000288602.7', 599, 'p', residue_mode='inter-residue',
+        end_pos=599)
     assert mane_p == braf_v600e_mane_p
 
     mane_p = await test_mane_transcript.get_mane_transcript(
-        'ENSP00000288602.7', 600, 600, 'p')
+        'ENSP00000288602.7', 600, 'p', end_pos=600)
     assert mane_p == braf_v600e_mane_p
 
     # EGFR L858R RefSeq Accessions
     mane_p = await test_mane_transcript.get_mane_transcript(
-        'NP_005219.2', 858, None, 'p')
+        'NP_005219.2', 858, 'p')
     assert mane_p == egfr_l858r_mane_p
 
     mane_p = await test_mane_transcript.get_mane_transcript(
-        'NP_005219.2', 858, 858, 'p')
+        'NP_005219.2', 858, 'p', end_pos=858)
     assert mane_p == egfr_l858r_mane_p
 
     # EGFR L858R Ensembl Accessions
     mane_p = await test_mane_transcript.get_mane_transcript(
-        'ENSP00000275493.2', 858, None, 'p')
+        'ENSP00000275493.2', 858, 'p')
     assert mane_p == egfr_l858r_mane_p
 
     mane_p = await test_mane_transcript.get_mane_transcript(
-        'ENSP00000275493.2', 858, 858, 'p')
+        'ENSP00000275493.2', 858, 'p', end_pos=858)
     assert mane_p == egfr_l858r_mane_p
 
     assert test_mane_transcript.get_mane_transcript(
-        'NP_004439.2', 755, 759, 'p')
+        'NP_004439.2', 755, 'p', end_pos=759)
 
     mane_p = await test_mane_transcript.get_mane_transcript(
-        'ENSP00000366997.4', 63, 63, 'P', gene='DIS3', ref='P',
-        try_longest_compatible=True)
+        'ENSP00000366997.4', 63, 'P', gene='DIS3', ref='P',
+        try_longest_compatible=True, end_pos=63)
     assert mane_p == {
         'gene': 'DIS3',
         'refseq': 'NP_055768.3',
@@ -316,56 +317,56 @@ async def test_c_to_mane_c(test_mane_transcript, braf_v600e_mane_c,
     cpy_braf_v600e_mane_c = copy.deepcopy(braf_v600e_mane_c)
     cpy_braf_v600e_mane_c['alt_ac'] = None
     mane_c = await test_mane_transcript.get_mane_transcript(
-        'NM_004333.4', 1799, None, 'c')
+        'NM_004333.4', 1799, 'c')
     assert mane_c == cpy_braf_v600e_mane_c
 
     mane_c = await test_mane_transcript.get_mane_transcript(
-        'NM_004333.4', 1798, None, 'c', residue_mode='inter-residue')
+        'NM_004333.4', 1798, 'c', residue_mode='inter-residue')
     assert mane_c == cpy_braf_v600e_mane_c
 
     mane_c = await test_mane_transcript.get_mane_transcript(
-        'NM_004333.4', 1798, 1798, 'c', residue_mode='inter-residue')
+        'NM_004333.4', 1798, 'c', residue_mode='inter-residue', end_pos=1798)
     assert mane_c == cpy_braf_v600e_mane_c
 
     mane_c = await test_mane_transcript.get_mane_transcript(
-        'NM_004333.5', 1799, None, 'C')
+        'NM_004333.5', 1799, 'C')
     assert mane_c == cpy_braf_v600e_mane_c
 
     mane_c = await test_mane_transcript.get_mane_transcript(
-        'NM_004333.6', 1799, None, 'c')
+        'NM_004333.6', 1799, 'c')
     assert mane_c == cpy_braf_v600e_mane_c
 
     # BRAF V600E Ensembl Accessions
     mane_c = await test_mane_transcript.get_mane_transcript(
-        'ENST00000288602.10', 1799, None, 'c')
+        'ENST00000288602.10', 1799, 'c')
     assert mane_c == cpy_braf_v600e_mane_c
 
     mane_c = await test_mane_transcript.get_mane_transcript(
-        'ENST00000288602.11', 1799, None, 'c')
+        'ENST00000288602.11', 1799, 'c')
     assert mane_c == cpy_braf_v600e_mane_c
 
     cpy_egfr_l858r_mane_c = copy.deepcopy(egfr_l858r_mane_c)
     cpy_egfr_l858r_mane_c['alt_ac'] = None
     # EGFR L858R RefSeq Accessions
     mane_c = await test_mane_transcript.get_mane_transcript(
-        'NM_005228.3', 2573, None, 'c')
+        'NM_005228.3', 2573, 'c')
     assert mane_c == cpy_egfr_l858r_mane_c
 
     mane_c = await test_mane_transcript.get_mane_transcript(
-        'NM_005228.4', 2573, None, 'c')
+        'NM_005228.4', 2573, 'c')
     assert mane_c == cpy_egfr_l858r_mane_c
 
     mane_c = await test_mane_transcript.get_mane_transcript(
-        'NM_005228.5', 2573, 2573, 'c')
+        'NM_005228.5', 2573, 'c', end_pos=2573)
     assert mane_c == cpy_egfr_l858r_mane_c
 
     # EGFR L858R Ensembl Accessions
     mane_c = await test_mane_transcript.get_mane_transcript(
-        'ENST00000275493.7', 2573, None, 'c')
+        'ENST00000275493.7', 2573, 'c')
     assert mane_c == cpy_egfr_l858r_mane_c
 
     mane_c = await test_mane_transcript.get_mane_transcript(
-        'ENST00000275493.6', 2573, None, 'c')
+        'ENST00000275493.6', 2573, 'c')
     assert mane_c == cpy_egfr_l858r_mane_c
 
 
@@ -419,12 +420,12 @@ async def test_no_matches(test_mane_transcript):
     """Test that invalid queries return None."""
     # Invalid ENST version
     mane_c = await test_mane_transcript.get_mane_transcript(
-        'ENST00000275493.15645', 2573, None, 'c'
+        'ENST00000275493.15645', 2573, 'c'
     )
     assert mane_c is None
 
     # Invalid residue-mode
     mane_c = await test_mane_transcript.get_mane_transcript(
-        'ENST00000288602.11', 2573, None, 'c', residue_mode='residues'
+        'ENST00000288602.11', 2573, 'c', residue_mode='residues'
     )
     assert mane_c is None

--- a/tests/unit/test_mane_transcript.py
+++ b/tests/unit/test_mane_transcript.py
@@ -242,7 +242,15 @@ async def test_p_to_mane_p(test_mane_transcript, braf_v600e_mane_p,
     """Test that p_to_mane_p method works correctly."""
     # BRAF V600E RefSeq Accessions
     mane_p = await test_mane_transcript.get_mane_transcript(
+        'NP_004324.2', 599, None, 'p', residue_mode='inter-residue')
+    assert mane_p == braf_v600e_mane_p
+
+    mane_p = await test_mane_transcript.get_mane_transcript(
         'NP_004324.2', 600, None, 'p')
+    assert mane_p == braf_v600e_mane_p
+
+    mane_p = await test_mane_transcript.get_mane_transcript(
+        'NP_004324.2', 599, 599, 'p', residue_mode='inter-residue')
     assert mane_p == braf_v600e_mane_p
 
     mane_p = await test_mane_transcript.get_mane_transcript(
@@ -251,7 +259,15 @@ async def test_p_to_mane_p(test_mane_transcript, braf_v600e_mane_p,
 
     # BRAF V600E Ensembl Accessions
     mane_p = await test_mane_transcript.get_mane_transcript(
+        'ENSP00000288602.7', 599, None, 'p', residue_mode='inter-residue')
+    assert mane_p == braf_v600e_mane_p
+
+    mane_p = await test_mane_transcript.get_mane_transcript(
         'ENSP00000288602.7', 600, None, 'p')
+    assert mane_p == braf_v600e_mane_p
+
+    mane_p = await test_mane_transcript.get_mane_transcript(
+        'ENSP00000288602.7', 599, 599, 'p', residue_mode='inter-residue')
     assert mane_p == braf_v600e_mane_p
 
     mane_p = await test_mane_transcript.get_mane_transcript(
@@ -301,6 +317,14 @@ async def test_c_to_mane_c(test_mane_transcript, braf_v600e_mane_c,
     cpy_braf_v600e_mane_c['alt_ac'] = None
     mane_c = await test_mane_transcript.get_mane_transcript(
         'NM_004333.4', 1799, None, 'c')
+    assert mane_c == cpy_braf_v600e_mane_c
+
+    mane_c = await test_mane_transcript.get_mane_transcript(
+        'NM_004333.4', 1798, None, 'c', residue_mode='inter-residue')
+    assert mane_c == cpy_braf_v600e_mane_c
+
+    mane_c = await test_mane_transcript.get_mane_transcript(
+        'NM_004333.4', 1798, 1798, 'c', residue_mode='inter-residue')
     assert mane_c == cpy_braf_v600e_mane_c
 
     mane_c = await test_mane_transcript.get_mane_transcript(
@@ -396,5 +420,11 @@ async def test_no_matches(test_mane_transcript):
     # Invalid ENST version
     mane_c = await test_mane_transcript.get_mane_transcript(
         'ENST00000275493.15645', 2573, None, 'c'
+    )
+    assert mane_c is None
+
+    # Invalid residue-mode
+    mane_c = await test_mane_transcript.get_mane_transcript(
+        'ENST00000288602.11', 2573, None, 'c', residue_mode='residues'
     )
     assert mane_c is None

--- a/tests/unit/test_mane_transcript.py
+++ b/tests/unit/test_mane_transcript.py
@@ -58,7 +58,7 @@ def braf_v600e_mane_p():
     return {
         'refseq': 'NP_001361187.1',
         'ensembl': 'ENSP00000496776.1',
-        'pos': (640, 640),
+        'pos': (639, 639),
         'status': 'MANE Select',
         'strand': '-',
         'gene': 'BRAF'
@@ -71,7 +71,7 @@ def egfr_l858r_mane_p():
     return {
         'refseq': 'NP_005219.2',
         'ensembl': 'ENSP00000275493.2',
-        'pos': (858, 858),
+        'pos': (857, 857),
         'status': 'MANE Select',
         'strand': '+',
         'gene': 'EGFR'
@@ -85,7 +85,7 @@ def braf_v600e_mane_c():
         'alt_ac': 'NC_000007.14',
         'refseq': 'NM_001374258.1',
         'ensembl': 'ENST00000644969.2',
-        'pos': (1919, 1919),
+        'pos': (1918, 1918),
         'status': 'MANE Select',
         'strand': '-',
         'coding_start_site': 226,
@@ -101,7 +101,7 @@ def egfr_l858r_mane_c():
         'alt_ac': 'NC_000007.14',
         'refseq': 'NM_005228.5',
         'ensembl': 'ENST00000275493.7',
-        'pos': (2573, 2573),
+        'pos': (2572, 2572),
         'status': 'MANE Select',
         'strand': '+',
         'coding_start_site': 261,
@@ -232,7 +232,7 @@ async def test__g_to_mane_c(test_mane_transcript, braf_mane_data,
 
 def test_get_mane_p(test_mane_transcript, braf_mane_data, braf_v600e_mane_p):
     """Test that _get_mane_p method works correctly."""
-    mane_p = test_mane_transcript._get_mane_p(braf_mane_data, (1918, 1920))
+    mane_p = test_mane_transcript._get_mane_p(braf_mane_data, (1917, 1919))
     assert mane_p == braf_v600e_mane_p
 
 
@@ -240,6 +240,17 @@ def test_get_mane_p(test_mane_transcript, braf_mane_data, braf_v600e_mane_p):
 async def test_p_to_mane_p(test_mane_transcript, braf_v600e_mane_p,
                            egfr_l858r_mane_p):
     """Test that p_to_mane_p method works correctly."""
+    mane_p = await test_mane_transcript.get_mane_transcript(
+        'ENSP00000366997.4', 63, 63, 'P', gene='DIS3', ref='P',
+        try_longest_compatible=True)
+    assert mane_p == {
+        'gene': 'DIS3',
+        'refseq': 'NP_055768.3',
+        'ensembl': 'ENSP00000366997.4',
+        'pos': (62, 62),
+        'strand': '-',
+        'status': 'MANE Select'
+    }
     # BRAF V600E RefSeq Accessions
     mane_p = await test_mane_transcript.get_mane_transcript(
         'NP_004324.2', 600, None, 'p')
@@ -286,7 +297,7 @@ async def test_p_to_mane_p(test_mane_transcript, braf_v600e_mane_p,
         'gene': 'DIS3',
         'refseq': 'NP_055768.3',
         'ensembl': 'ENSP00000366997.4',
-        'pos': (63, 63),
+        'pos': (62, 62),
         'strand': '-',
         'status': 'MANE Select'
     }
@@ -350,15 +361,15 @@ async def test_g_to_mane_c(test_mane_transcript, egfr_l858r_mane_c,
                            braf_v600e_mane_c, grch38):
     """Test that g_to_mane_c method works correctly."""
     mane_c = await test_mane_transcript.g_to_mane_c(
-        'NC_000007.13', 55259515, None, gene='EGFR')
+        'NC_000007.13', 55259514, None, gene='EGFR')
     assert mane_c == egfr_l858r_mane_c
 
     mane_c = await test_mane_transcript.g_to_mane_c(
-        'NC_000007.13', 55259515, 55259515, gene='EGFR')
+        'NC_000007.13', 55259514, 55259514, gene='EGFR')
     assert mane_c == egfr_l858r_mane_c
 
     mane_c = await test_mane_transcript.g_to_mane_c(
-        'NC_000007.13', 140453136, None, gene='BRAF')
+        'NC_000007.13', 140453137, None, gene='BRAF')
     assert mane_c == braf_v600e_mane_c
 
     resp = await test_mane_transcript.g_to_mane_c(
@@ -366,8 +377,8 @@ async def test_g_to_mane_c(test_mane_transcript, egfr_l858r_mane_c,
     assert resp == grch38
 
     resp = await test_mane_transcript.g_to_mane_c(
-        'NC_000007.13', 140453136, None)
-    grch38["pos"] = (140753336, 140753336)
+        'NC_000007.13', 140453135, None)
+    grch38["pos"] = (140753335, 140753335)
     assert resp == grch38
 
     resp = await test_mane_transcript.g_to_mane_c(

--- a/tests/unit/test_residue_mode.py
+++ b/tests/unit/test_residue_mode.py
@@ -5,18 +5,18 @@ from uta_tools.data_sources.residue_mode import get_inter_residue_pos
 def test_get_inter_residue_pos():
     """Test that get_inter_residue_pos method works correctly"""
     expected = ((599, 599), None)
-    resp = get_inter_residue_pos(600, None, 'residue')
+    resp = get_inter_residue_pos(600, 'residue')
     assert resp == expected
 
-    resp = get_inter_residue_pos(600, 600, 'residue')
+    resp = get_inter_residue_pos(600, 'residue', end_pos=600)
     assert resp == expected
 
-    resp = get_inter_residue_pos(599, None, 'inter-residue')
+    resp = get_inter_residue_pos(599, 'inter-residue')
     assert resp == expected
 
-    resp = get_inter_residue_pos(599, 599, 'inter-residue')
+    resp = get_inter_residue_pos(599, 'inter-residue', end_pos=599)
     assert resp == expected
 
-    resp = get_inter_residue_pos(600, None, 'test')
+    resp = get_inter_residue_pos(600, 'test')
     assert resp == (None, "residue_mode must be either `residue` "
                           "or `inter-residue`, not `test`")

--- a/tests/unit/test_residue_mode.py
+++ b/tests/unit/test_residue_mode.py
@@ -1,0 +1,22 @@
+"""Module for testing residue mode"""
+from uta_tools.data_sources.residue_mode import get_inter_residue_pos
+
+
+def test_get_inter_residue_pos():
+    """Test that get_inter_residue_pos method works correctly"""
+    expected = ((599, 599), None)
+    resp = get_inter_residue_pos(600, None, 'residue')
+    assert resp == expected
+
+    resp = get_inter_residue_pos(600, 600, 'residue')
+    assert resp == expected
+
+    resp = get_inter_residue_pos(599, None, 'inter-residue')
+    assert resp == expected
+
+    resp = get_inter_residue_pos(599, 599, 'inter-residue')
+    assert resp == expected
+
+    resp = get_inter_residue_pos(600, None, 'test')
+    assert resp == (None, "residue_mode must be either `residue` "
+                          "or `inter-residue`, not `test`")

--- a/tests/unit/test_seqrepo_access.py
+++ b/tests/unit/test_seqrepo_access.py
@@ -9,31 +9,6 @@ def test_seqrepo_access():
     return SeqRepoAccess()
 
 
-def test__get_start_end(test_seqrepo_access):
-    """Test that _get_start_end method works correctly."""
-    resp = test_seqrepo_access._get_start_end(600)
-    assert resp == ((599, 600), None)
-
-    resp = test_seqrepo_access._get_start_end(600, 600)
-    assert resp == ((599, 600), None)
-
-    resp = test_seqrepo_access._get_start_end(
-        600, end=600, residue_mode="residue")
-    assert resp == ((599, 600), None)
-
-    resp = test_seqrepo_access._get_start_end(
-        600, residue_mode="inter-residue")
-    assert resp == ((600, 601), None)
-
-    resp = test_seqrepo_access._get_start_end(
-        600, end=600, residue_mode="inter-residue")
-    assert resp == ((600, 601), None)
-
-    resp = test_seqrepo_access._get_start_end(600, residue_mode="mode")
-    assert resp == (None, "residue_mode must be either `inter-residue` or "
-                          "`residue`, not `mode`")
-
-
 def test_is_valid_input_sequence(test_seqrepo_access):
     """Test that is_valid_input_sequence method works correctly"""
     resp = test_seqrepo_access.is_valid_input_sequence("NP_004324.2", 600)

--- a/uta_tools/data_sources/mane_transcript.py
+++ b/uta_tools/data_sources/mane_transcript.py
@@ -445,7 +445,7 @@ class MANETranscript:
         return None
 
     async def get_mane_transcript(
-            self, ac: str, start_pos: int, end_pos: int,
+            self, ac: str, start_pos: int, end_pos: Optional[int],
             start_annotation_layer: str, gene: Optional[str] = None,
             ref: Optional[str] = None, try_longest_compatible: bool = False,
             residue_mode: ResidueMode = ResidueMode.RESIDUE
@@ -454,7 +454,7 @@ class MANETranscript:
 
         :param str ac: Accession
         :param int start_pos: Start position change
-        :param int end_pos: End position change
+        :param Optional[int] end_pos: End position change
         :param str start_annotation_layer: Starting annotation layer.
             Must be either `p`, `c`, or `g`.
         :param str gene: Gene symbol

--- a/uta_tools/data_sources/mane_transcript.py
+++ b/uta_tools/data_sources/mane_transcript.py
@@ -371,7 +371,7 @@ class MANETranscript:
         :return: Data for longest compatible transcript
         """
         inter_residue_pos, warning = get_inter_residue_pos(
-            start_pos, end_pos, residue_mode)
+            start_pos, residue_mode, end_pos=end_pos)
         if not inter_residue_pos:
             return None
         residue_mode = ResidueMode.INTER_RESIDUE
@@ -445,8 +445,8 @@ class MANETranscript:
         return None
 
     async def get_mane_transcript(
-            self, ac: str, start_pos: int, end_pos: Optional[int],
-            start_annotation_layer: str, gene: Optional[str] = None,
+            self, ac: str, start_pos: int, start_annotation_layer: str,
+            end_pos: Optional[int] = None, gene: Optional[str] = None,
             ref: Optional[str] = None, try_longest_compatible: bool = False,
             residue_mode: ResidueMode = ResidueMode.RESIDUE
     ) -> Optional[Dict]:
@@ -454,9 +454,10 @@ class MANETranscript:
 
         :param str ac: Accession
         :param int start_pos: Start position change
-        :param Optional[int] end_pos: End position change
         :param str start_annotation_layer: Starting annotation layer.
             Must be either `p`, `c`, or `g`.
+        :param Optional[int] end_pos: End position change. If `None` assumes
+            both  `start_pos` and `end_pos` have same values.
         :param str gene: Gene symbol
         :param str ref: Reference at position given during input
         :param bool try_longest_compatible: `True` if should try longest
@@ -469,7 +470,7 @@ class MANETranscript:
             Else, `None`
         """
         inter_residue_pos, warning = get_inter_residue_pos(
-            start_pos, end_pos, residue_mode)
+            start_pos, residue_mode, end_pos=end_pos)
         if not inter_residue_pos:
             return None
         start_pos, end_pos = inter_residue_pos

--- a/uta_tools/data_sources/residue_mode.py
+++ b/uta_tools/data_sources/residue_mode.py
@@ -1,0 +1,31 @@
+"""Module for converting positions to inter-residue coordinates"""
+from typing import Optional, Tuple
+
+from uta_tools.schemas import ResidueMode
+from uta_tools import logger
+
+
+def get_inter_residue_pos(
+        start_pos: int, end_pos: int, residue_mode: str
+) -> Tuple[Optional[Tuple[int, int]], Optional[str]]:
+    """Return inter-residue position
+
+    :param str start_pos: Start position
+    :param str end_pos: End position
+    :param str residue_mode: `inter-residue` if start/end are 0 based coords.
+        `residue` if start/end are 1 based coords
+    :return: Inter-residue coordinates, warning
+    """
+    residue_mode = residue_mode.lower()
+    if residue_mode == ResidueMode.RESIDUE:
+        start_pos -= 1
+        if end_pos is None:
+            end_pos = start_pos
+        else:
+            end_pos -= 1
+    elif residue_mode != ResidueMode.INTER_RESIDUE:
+        msg = f"residue_mode must be either `residue` or `inter-residue`," \
+              f" not {residue_mode}"
+        logger.warning(msg)
+        return None, msg
+    return (start_pos, end_pos), None

--- a/uta_tools/data_sources/residue_mode.py
+++ b/uta_tools/data_sources/residue_mode.py
@@ -28,7 +28,7 @@ def get_inter_residue_pos(
             end_pos = start_pos
     else:
         msg = f"residue_mode must be either `residue` or `inter-residue`," \
-              f" not {residue_mode}"
+              f" not `{residue_mode}`"
         logger.warning(msg)
         return None, msg
     return (start_pos, end_pos), None

--- a/uta_tools/data_sources/residue_mode.py
+++ b/uta_tools/data_sources/residue_mode.py
@@ -6,14 +6,15 @@ from uta_tools import logger
 
 
 def get_inter_residue_pos(
-        start_pos: int, end_pos: Optional[int], residue_mode: str
+        start_pos: int, residue_mode: str, end_pos: Optional[int] = None
 ) -> Tuple[Optional[Tuple[int, int]], Optional[str]]:
     """Return inter-residue position
 
     :param int start_pos: Start position
-    :param Optional[int] end_pos: End position
     :param str residue_mode: `inter-residue` if start/end are 0 based coords.
         `residue` if start/end are 1 based coords
+    :param Optional[int] end_pos: End position. If `None` assumes both
+        `start` and `end` have same values.
     :return: Inter-residue coordinates, warning
     """
     residue_mode = residue_mode.lower()

--- a/uta_tools/data_sources/residue_mode.py
+++ b/uta_tools/data_sources/residue_mode.py
@@ -6,12 +6,12 @@ from uta_tools import logger
 
 
 def get_inter_residue_pos(
-        start_pos: int, end_pos: int, residue_mode: str
+        start_pos: int, end_pos: Optional[int], residue_mode: str
 ) -> Tuple[Optional[Tuple[int, int]], Optional[str]]:
     """Return inter-residue position
 
-    :param str start_pos: Start position
-    :param str end_pos: End position
+    :param int start_pos: Start position
+    :param Optional[int] end_pos: End position
     :param str residue_mode: `inter-residue` if start/end are 0 based coords.
         `residue` if start/end are 1 based coords
     :return: Inter-residue coordinates, warning
@@ -23,7 +23,10 @@ def get_inter_residue_pos(
             end_pos = start_pos
         else:
             end_pos -= 1
-    elif residue_mode != ResidueMode.INTER_RESIDUE:
+    elif residue_mode == ResidueMode.INTER_RESIDUE:
+        if end_pos is None:
+            end_pos = start_pos
+    else:
         msg = f"residue_mode must be either `residue` or `inter-residue`," \
               f" not {residue_mode}"
         logger.warning(msg)

--- a/uta_tools/data_sources/seqrepo_access.py
+++ b/uta_tools/data_sources/seqrepo_access.py
@@ -46,13 +46,14 @@ class SeqRepoAccess:
 
         :param str ac: Accession
         :param int start: Start pos change
-        :param Optional[int] end: End pos change
+        :param Optional[int] end: End pos change. If `None` assumes both
+            `start` and `end` have same values.
         :param str residue_mode: Residue mode for start/end positions
             Must be either `inter-residue` or `residue`
         :return: Sequence at position (if accession and positions actually
             exist), warning
         """
-        pos, warning = get_inter_residue_pos(start, end, residue_mode)
+        pos, warning = get_inter_residue_pos(start, residue_mode, end_pos=end)
         if pos is None:
             return None, warning
         else:

--- a/uta_tools/data_sources/uta_database.py
+++ b/uta_tools/data_sources/uta_database.py
@@ -176,7 +176,8 @@ class UTADatabase:
             for create_index in indexes:
                 await self.execute_query(create_index)
 
-    def _transform_list(self, li: List) -> List[List[Any]]:
+    @staticmethod
+    def _transform_list(li: List) -> List[List[Any]]:
         """Transform list to only contain field values
 
         :param List li: List of asyncpg.Record objects
@@ -256,8 +257,9 @@ class UTADatabase:
             return None, msg
         return cds_se_i[0][0].split(';'), None
 
+    @staticmethod
     def _validate_exon(
-            self, transcript: str, tx_exons: List[str],
+            transcript: str, tx_exons: List[str],
             exon_number: Optional[int] = None) -> Tuple[Optional[List], Optional[str]]:  # noqa: E501
         """Validate that exon number is valid
 
@@ -421,7 +423,7 @@ class UTADatabase:
             cds_start_end = cds_start_end[0]
             if cds_start_end[0] is not None \
                     and cds_start_end[1] is not None:
-                return cds_start_end
+                return cds_start_end[0], cds_start_end[1]
         else:
             logger.warning(f"Unable to get coding start/end site for "
                            f"accession: {tx_ac}")
@@ -587,7 +589,7 @@ class UTADatabase:
             alt_exon_id=alt_exon_id,
         )
 
-    async def get_mane_c_genomic_data(self, ac: str, alt_ac: str,
+    async def get_mane_c_genomic_data(self, ac: str, alt_ac: Optional[str],
                                       start_pos: int,
                                       end_pos: int) -> Optional[Dict]:
         """Get MANE Transcript and genomic data.

--- a/uta_tools/data_sources/uta_database.py
+++ b/uta_tools/data_sources/uta_database.py
@@ -15,24 +15,21 @@ from asyncpg.exceptions import InvalidAuthorizationSpecificationError
 class UTADatabase:
     """Class for connecting and querying UTA database."""
 
-    def __init__(self, db_url: str = UTA_DB_URL, db_pwd: str = '',
-                 liftover_from: str = 'hg19',
-                 liftover_to: str = 'hg38') -> None:
+    def __init__(self, db_url: str = UTA_DB_URL, db_pwd: str = '') -> None:
         """Initialize DB class.
         After initializing, you must run `_create_genomic_table()`
 
         :param str db_url: PostgreSQL connection URL
             Format: `driver://user:pass@host/database/schema`
         :param str db_pwd: User's password for uta database
-        :param str liftover_from: Assembly to liftover from
-        :param str liftover_to: Assembly to liftover to
         """
         self.schema = None
         self.db_url = db_url
         self.db_pwd = db_pwd
         self._connection_pool = None
         self.args = self._get_conn_args()
-        self.liftover = LiftOver(liftover_from, liftover_to)
+        self.liftover_37_to_38 = LiftOver('hg19', 'hg38')
+        self.liftover_38_to_37 = LiftOver('hg38', 'hg19')
 
     @staticmethod
     def _update_db_url(db_pwd: str, db_url: str) -> str:
@@ -832,7 +829,7 @@ class UTADatabase:
         :return: [Target chromosome, target position, target strand,
             conversion_chain_score] for hg38 assembly
         """
-        liftover = self.liftover.convert_coordinate(chromosome, pos)
+        liftover = self.liftover_37_to_38.convert_coordinate(chromosome, pos)
         if liftover is None or len(liftover) == 0:
             logger.warning(f"{pos} does not exist on {chromosome}")
             return None

--- a/uta_tools/uta_tools.py
+++ b/uta_tools/uta_tools.py
@@ -389,7 +389,7 @@ class UTATools:
         if residue_mode == ResidueMode.RESIDUE:
             pos += 1
         mane_data = await self.mane_transcript.get_mane_transcript(
-            alt_ac, pos, None, 'g', gene=gene,
+            alt_ac, pos, 'g', gene=gene,
             try_longest_compatible=True, residue_mode=residue_mode
         )
         if not mane_data:

--- a/uta_tools/uta_tools.py
+++ b/uta_tools/uta_tools.py
@@ -43,7 +43,8 @@ class UTATools:
             self.seqrepo_access, self.transcript_mappings,
             self.mane_transcript_mappings, self.uta_db)
 
-    def service_meta(self) -> ServiceMeta:
+    @staticmethod
+    def service_meta() -> ServiceMeta:
         """Return ServiceMeta for uta_tools
 
         :return: ServiceMeta object
@@ -53,8 +54,9 @@ class UTATools:
             response_datetime=datetime.now()
         )
 
+    @staticmethod
     def _return_warnings(
-            self, resp: Union[GenomicDataResponse, TranscriptExonDataResponse],
+            resp: Union[GenomicDataResponse, TranscriptExonDataResponse],
             warning_msg: str) -> Union[GenomicDataResponse, TranscriptExonDataResponse]:  # noqa: E501
         """Add warnings to response object
 
@@ -314,7 +316,7 @@ class UTATools:
 
         if transcript is None:
             warnings = await self._set_mane_genomic_data(
-                params, gene, alt_ac, pos, strand, is_start)
+                params, gene, alt_ac, pos, strand, is_start, residue_mode)
             if warnings:
                 return self._return_warnings(resp, warnings)
         else:
@@ -331,9 +333,10 @@ class UTATools:
         resp.transcript_exon_data = TranscriptExonData(**params)
         return resp
 
-    def _get_gene_and_alt_ac(self,
-                             genes_alt_acs: Dict,
-                             gene: Optional[str]) -> Tuple[Optional[Tuple[str, str]], Optional[str]]:  # noqa; E501
+    @staticmethod
+    def _get_gene_and_alt_ac(
+            genes_alt_acs: Dict, gene: Optional[str]
+    ) -> Tuple[Optional[Tuple[str, str]], Optional[str]]:
         """Return gene genomic accession
 
         :param Dict genes_alt_acs: Dictionary containing genes and
@@ -368,9 +371,10 @@ class UTATools:
         gene = output_gene if output_gene else input_gene
         return (gene, alt_ac), None
 
-    async def _set_mane_genomic_data(self, params: Dict, gene: str,
-                                     alt_ac: str, pos: int, strand: int,
-                                     is_start: bool) -> Optional[str]:
+    async def _set_mane_genomic_data(
+            self, params: Dict, gene: str, alt_ac: str, pos: int, strand: int,
+            is_start: bool, residue_mode
+    ) -> Optional[str]:
         """Set genomic data in `params` found from MANE.
 
         :param Dict params: Parameters for response
@@ -382,9 +386,11 @@ class UTATools:
             `pos` is end position.
         :return: Warnings if found
         """
+        if residue_mode == ResidueMode.RESIDUE:
+            pos += 1
         mane_data = await self.mane_transcript.get_mane_transcript(
             alt_ac, pos, None, 'g', gene=gene,
-            try_longest_compatible=True
+            try_longest_compatible=True, residue_mode=residue_mode
         )
         if not mane_data:
             msg = f"Unable to find mane data for {alt_ac} with position {pos}"
@@ -489,7 +495,8 @@ class UTATools:
                               is_start=is_start, strand=strand_to_use)
         return None
 
-    def _set_exon_offset(self, params: Dict, start: int, end: int, pos: int,
+    @staticmethod
+    def _set_exon_offset(params: Dict, start: int, end: int, pos: int,
                          is_start: bool, strand: int) -> None:
         """Set `exon_offset` in params.
 
@@ -527,7 +534,8 @@ class UTATools:
             result.append((int(coords[0]), int(coords[1])))
         return result
 
-    def _get_exon_number(self, tx_exons: List, tx_pos: int) -> int:
+    @staticmethod
+    def _get_exon_number(tx_exons: List, tx_pos: int) -> int:
         """Find exon number.
 
         :param List tx_exons: List of exon coordinates

--- a/uta_tools/uta_tools.py
+++ b/uta_tools/uta_tools.py
@@ -20,8 +20,6 @@ class UTATools:
                  lrg_refseqgene_path: str = LRG_REFSEQGENE_PATH,
                  mane_data_path: str = MANE_SUMMARY_PATH,
                  db_url: str = UTA_DB_URL, db_pwd: str = '',
-                 liftover_from: str = 'hg19',
-                 liftover_to: str = 'hg38'
                  ):
         """Initialize UTATools class
 
@@ -32,8 +30,6 @@ class UTATools:
         :param str db_url: PostgreSQL connection URL
             Format: `driver://user:pass@host/database/schema`
         :param str db_pwd: User's password for uta database
-        :param str liftover_from: Assembly to liftover from
-        :param str liftover_to: Assembly to liftover to
         """
         self.seqrepo_access = SeqRepoAccess(
             seqrepo_data_path=seqrepo_data_path)
@@ -42,9 +38,7 @@ class UTATools:
             lrg_refseqgene_path=lrg_refseqgene_path)
         self.mane_transcript_mappings = MANETranscriptMappings(
             mane_data_path=mane_data_path)
-        self.uta_db = UTADatabase(
-            db_url=db_url, db_pwd=db_pwd, liftover_from=liftover_from,
-            liftover_to=liftover_to)
+        self.uta_db = UTADatabase(db_url=db_url, db_pwd=db_pwd)
         self.mane_transcript = MANETranscript(
             self.seqrepo_access, self.transcript_mappings,
             self.mane_transcript_mappings, self.uta_db)

--- a/uta_tools/version.py
+++ b/uta_tools/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.10"  # noqa: D100
+__version__ = "0.0.11"  # noqa: D100


### PR DESCRIPTION
Closes #14 

Notes
- `get_mane_transcript` method returns inter-residue (0-based) coordinates.
    - Decided against checking residue_mode in each method, so decided to go with the main method when getting a mane transcript. If you think it's best to check in each method, I can switch to doing that
- Added another liftover to go from 37 <--> 38 (will be used in variation-normalizer)