### PR TITLE
Fix some create_genomic_table() issues + add DB create() method

### DIFF
--- a/uta_tools/data_sources/uta_database.py
+++ b/uta_tools/data_sources/uta_database.py
@@ -145,7 +145,13 @@ class UTADatabase:
             """
         )
         genomic_table_exists = await self.execute_query(check_table_exists)
-        genomic_table_exists = genomic_table_exists[0]
+        genomic_table_exists = genomic_table_exists[0].get("exists")
+        if genomic_table_exists is None:
+            logger.critical(
+                "SELECT EXISTS query in UTADatabase._create_genomic_table "
+                "returned invalid response"
+            )
+            raise ValueError("SELECT EXISTS query returned invalid response")
         if not genomic_table_exists:
             create_genomic_table = (
                 f"""
@@ -172,7 +178,7 @@ class UTADatabase:
 
             indexes = [
                 f"""CREATE INDEX alt_pos_index ON {self.schema}.genomic (alt_ac, alt_start_i, alt_end_i);""",  # noqa: E501
-                f"""CREATE INDEX gene_alt_index ON {self.schema}.genomic (hgnc, alt_ac);"""  # noqa: E501
+                f"""CREATE INDEX gene_alt_index ON {self.schema}.genomic (hgnc, alt_ac);""",  # noqa: E501
                 f"""CREATE INDEX alt_ac_index ON {self.schema}.genomic (alt_ac);"""  # noqa: E501
             ]
             for create_index in indexes:

--- a/uta_tools/data_sources/uta_database.py
+++ b/uta_tools/data_sources/uta_database.py
@@ -22,8 +22,10 @@ class UTADatabase:
     """Class for connecting and querying UTA database."""
 
     def __init__(self, db_url: str = UTA_DB_URL, db_pwd: str = "") -> None:
-        """Initialize DB class.
-        After initializing, you must run `_create_genomic_table()`
+        """Initialize DB class. Downstream libraries should use the create()
+        method to construct a new instance:
+
+        >>> db = await UTADatabase.create()
 
         :param str db_url: PostgreSQL connection URL
             Format: `driver://user:pass@host/database/schema`
@@ -115,12 +117,17 @@ class UTADatabase:
                 raise Exception("Could not create connection pool")
 
     @classmethod
-    async def create(cls: Type[UTADatabaseType]) -> UTADatabaseType:
+    async def create(
+            cls: Type[UTADatabaseType], db_url: str = UTA_DB_URL,
+            db_pwd: str = "") -> UTADatabaseType:
         """Provide fully-initialized class instance (a la factory pattern)
         :param UTADatabaseType cls: supplied implicitly
+        :param str db_url: PostgreSQL connection URL
+            Format: `driver://user:pass@host/database/schema`
+        :param str db_pwd: User's password for uta database
         :return: UTA DB access class instance
         """
-        self = cls()
+        self = cls(db_url, db_pwd)
         await self._create_genomic_table()
         await self.create_pool()
         return self


### PR DESCRIPTION
* Extract "exists" value from `genomic_table_exists` query
* Fix `CREATE_INDEX` queries typo
* Add factory-style method to `UTADatabase` -- I'm not horribly attached to this but I think it's helpful to provide when classes have some initialization requirements outside of `__init__`

I wasn't sure of a good way to write tests without some kind of mock DB class, let me know if you have thoughts
